### PR TITLE
Type simplification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.34"
-async-trait = "0.1.42"
 futures = "0.3.8"
 petgraph = "0.5.1"
 serde_json = "1.0"

--- a/src/saga_action_func.rs
+++ b/src/saga_action_func.rs
@@ -14,7 +14,6 @@ use core::any::type_name;
 use core::fmt;
 use core::fmt::Debug;
 use core::future::Future;
-use core::marker::PhantomData;
 use futures::future::BoxFuture;
 use std::sync::Arc;
 
@@ -36,96 +35,45 @@ use std::sync::Arc;
 pub type ActionFuncResult<T, E> = Result<T, E>;
 
 /**
+ * Trait that expresses the requirements for async functions to be used with
+ * `ActionFunc`. This exists just to express the relationships between the types
+ * involved in the function, so that they don't have to be repeated everywhere.
+ * You don't need to implement it yourself -- a blanket implementation is
+ * provided.
+ */
+pub trait ActionFn<'c, S: SagaType>: Send + Sync + 'static {
+    /** Type returned when the future finally resolves. */
+    type Output;
+    /** Type of the future returned when the function is called. */
+    type Future: Future<Output = Self::Output> + Send + 'c;
+    /** Call the function. */
+    fn act(&'c self, ctx: ActionContext<S>) -> Self::Future;
+}
+
+/* Blanket impl for Fn types returning futures */
+impl<'c, F, S, FF> ActionFn<'c, S> for F
+where
+    S: SagaType,
+    F: Fn(ActionContext<S>) -> FF + Send + Sync + 'static,
+    FF: std::future::Future + Send + 'c,
+{
+    type Future = FF;
+    type Output = FF::Output;
+    fn act(&'c self, ctx: ActionContext<S>) -> Self::Future {
+        self(ctx)
+    }
+}
+
+/**
  * Implementation of [`Action`] that uses ordinary functions for the action and
  * undo action
  */
-/*
- * The monstrous type parameters here are simpler than they look.  First,
- * `UserType` encapsulates a bunch of types provided by the consumer.  See
- * `SagaType` for more on that.
- *
- * Ultimately, `ActionFunc` just wraps two asynchronous functions.  Both
- * consume an `ActionContext`.  On success, the action function produces a type
- * that impls `ActionData` and the undo function produces nothing.  Because
- * they're asynchronous and because the first function can produce any type that
- * impls `ActionData`, we get this explosion of type parameters and trait
- * bounds.
- */
-pub struct ActionFunc<
-    UserType,
-    ActionFutType,
-    ActionFuncType,
-    ActionFuncOutput,
-    UndoFutType,
-    UndoFuncType,
-> where
-    UserType: SagaType,
-    ActionFuncType:
-        Fn(ActionContext<UserType>) -> ActionFutType + Send + Sync + 'static,
-    ActionFutType: Future<Output = ActionFuncResult<ActionFuncOutput, ActionError>>
-        + Send
-        + 'static,
-    ActionFuncOutput: ActionData,
-    UndoFuncType:
-        Fn(ActionContext<UserType>) -> UndoFutType + Send + Sync + 'static,
-    UndoFutType: Future<Output = UndoResult> + Send + 'static,
-{
+pub struct ActionFunc<ActionFuncType, UndoFuncType> {
     action_func: ActionFuncType,
     undo_func: UndoFuncType,
-    /*
-     * The PhantomData type parameter below deserves some explanation.  First:
-     * this struct needs to store the above fields of type ActionFuncType and
-     * UndoFuncType.  These are async functions, so we need additional type
-     * parameters and trait bounds to describe the futures that they produce.
-     * But we don't actually use these futures in the struct.  Consumers
-     * implicitly specify them when they specify the corresponding function type
-     * parameters.  So far, this is a typical use case for PhantomData to
-     * reference these type parameters without storing them.
-     *
-     * Like many future types, ActionFutType and UndoFutType will be Send, but
-     * not necessarily Sync.  (We don't want to impose Sync on the caller
-     * because many useful futures are not Sync -- like
-     * hyper::client::ResponseFuture, for example.)  As a result, the obvious
-     * choice of `PhantomData<(ActionFutType, UndoFutType)>` won't be Sync, and
-     * then this struct (ActionFunc) won't be Sync -- and that's bad.  See the
-     * comment on the Action trait for why this must be Sync.
-     *
-     * On the other hand, the type `PhantomData<fn() -> (ActionFutType,
-     * UndoFutType)>` is Sync and also satisfies our need to reference these
-     * type parameters in the struct's contents.
-     */
-    #[allow(clippy::type_complexity)]
-    phantom: PhantomData<fn() -> (UserType, ActionFutType, UndoFutType)>,
 }
 
-impl<
-        UserType,
-        ActionFutType,
-        ActionFuncType,
-        ActionFuncOutput,
-        UndoFutType,
-        UndoFuncType,
-    >
-    ActionFunc<
-        UserType,
-        ActionFutType,
-        ActionFuncType,
-        ActionFuncOutput,
-        UndoFutType,
-        UndoFuncType,
-    >
-where
-    UserType: SagaType,
-    ActionFuncType:
-        Fn(ActionContext<UserType>) -> ActionFutType + Send + Sync + 'static,
-    ActionFutType: Future<Output = ActionFuncResult<ActionFuncOutput, ActionError>>
-        + Send
-        + 'static,
-    ActionFuncOutput: ActionData,
-    UndoFuncType:
-        Fn(ActionContext<UserType>) -> UndoFutType + Send + Sync + 'static,
-    UndoFutType: Future<Output = UndoResult> + Send + 'static,
-{
+impl<ActionFuncType, UndoFuncType> ActionFunc<ActionFuncType, UndoFuncType> {
     /**
      * Construct an [`Action`] from a pair of functions, using `action_func` for
      * the action and `undo_func` for the undo action
@@ -135,11 +83,21 @@ where
      * interfaces of its own so there's generally no need to have the specific
      * type.)
      */
-    pub fn new_action(
+    pub fn new_action<UserType, ActionFuncOutput>(
         action_func: ActionFuncType,
         undo_func: UndoFuncType,
-    ) -> Arc<dyn Action<UserType>> {
-        Arc::new(ActionFunc { action_func, undo_func, phantom: PhantomData })
+    ) -> Arc<dyn Action<UserType>>
+    where
+        UserType: SagaType,
+        for<'c> ActionFuncType: ActionFn<
+            'c,
+            UserType,
+            Output = ActionFuncResult<ActionFuncOutput, ActionError>,
+        >,
+        ActionFuncOutput: ActionData,
+        for<'c> UndoFuncType: ActionFn<'c, UserType, Output = UndoResult>,
+    {
+        Arc::new(ActionFunc { action_func, undo_func })
     }
 }
 
@@ -147,71 +105,43 @@ where
  * TODO-cleanup why can't new_action_noop_undo live in the Action namespace?
  */
 
-async fn undo_noop<UserType: SagaType>(
-    _: ActionContext<UserType>,
-) -> UndoResult {
-    // TODO-log
-    Ok(())
-}
-
 /**
  * Given a function `f`, return an `ActionFunc` that uses `f` as the action and
  * provides a no-op undo function (which does nothing and always succeeds).
  */
-pub fn new_action_noop_undo<
-    UserType,
-    ActionFutType,
-    ActionFuncType,
-    ActionFuncOutput,
->(
+pub fn new_action_noop_undo<UserType, ActionFuncType, ActionFuncOutput>(
     f: ActionFuncType,
 ) -> Arc<dyn Action<UserType>>
 where
     UserType: SagaType,
-    ActionFuncType:
-        Fn(ActionContext<UserType>) -> ActionFutType + Send + Sync + 'static,
-    ActionFutType: Future<Output = ActionFuncResult<ActionFuncOutput, ActionError>>
-        + Send
-        + 'static,
+    for<'c> ActionFuncType: ActionFn<
+        'c,
+        UserType,
+        Output = ActionFuncResult<ActionFuncOutput, ActionError>,
+    >,
     ActionFuncOutput: ActionData,
 {
-    ActionFunc::new_action(f, undo_noop)
+    ActionFunc::new_action(f, |_| async { Ok(()) })
 }
 
-impl<
-        UserType,
-        ActionFutType,
-        ActionFuncType,
-        ActionFuncOutput,
-        UndoFutType,
-        UndoFuncType,
-    > Action<UserType>
-    for ActionFunc<
-        UserType,
-        ActionFutType,
-        ActionFuncType,
-        ActionFuncOutput,
-        UndoFutType,
-        UndoFuncType,
-    >
+impl<UserType, ActionFuncType, ActionFuncOutput, UndoFuncType> Action<UserType>
+    for ActionFunc<ActionFuncType, UndoFuncType>
 where
     UserType: SagaType,
-    ActionFuncType:
-        Fn(ActionContext<UserType>) -> ActionFutType + Send + Sync + 'static,
-    ActionFutType: Future<Output = ActionFuncResult<ActionFuncOutput, ActionError>>
-        + Send
-        + 'static,
+    for<'c> ActionFuncType: ActionFn<
+        'c,
+        UserType,
+        Output = ActionFuncResult<ActionFuncOutput, ActionError>,
+    >,
     ActionFuncOutput: ActionData,
-    UndoFuncType:
-        Fn(ActionContext<UserType>) -> UndoFutType + Send + Sync + 'static,
-    UndoFutType: Future<Output = UndoResult> + Send + 'static,
+    for<'c> UndoFuncType: ActionFn<'c, UserType, Output = UndoResult>,
 {
     fn do_it<'f>(
         &'f self,
         sgctx: ActionContext<UserType>,
     ) -> BoxFuture<'f, ActionResult> {
         Box::pin(async move {
-            let fut = (self.action_func)(sgctx);
+            let fut = self.action_func.act(sgctx);
             /*
              * Execute the caller's function and translate its type into the generic
              * JsonValue that the framework uses to store action outputs.
@@ -229,37 +159,12 @@ where
         &'f self,
         sgctx: ActionContext<UserType>,
     ) -> BoxFuture<'f, UndoResult> {
-        Box::pin((self.undo_func)(sgctx))
+        Box::pin(self.undo_func.act(sgctx))
     }
 }
 
-impl<
-        UserType,
-        ActionFutType,
-        ActionFuncType,
-        ActionFuncOutput,
-        UndoFutType,
-        UndoFuncType,
-    > Debug
-    for ActionFunc<
-        UserType,
-        ActionFutType,
-        ActionFuncType,
-        ActionFuncOutput,
-        UndoFutType,
-        UndoFuncType,
-    >
-where
-    UserType: SagaType,
-    ActionFuncType:
-        Fn(ActionContext<UserType>) -> ActionFutType + Send + Sync + 'static,
-    ActionFutType: Future<Output = ActionFuncResult<ActionFuncOutput, ActionError>>
-        + Send
-        + 'static,
-    ActionFuncOutput: ActionData,
-    UndoFuncType:
-        Fn(ActionContext<UserType>) -> UndoFutType + Send + Sync + 'static,
-    UndoFutType: Future<Output = UndoResult> + Send + 'static,
+impl<ActionFuncType, UndoFuncType> Debug
+    for ActionFunc<ActionFuncType, UndoFuncType>
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         /*

--- a/src/saga_action_func.rs
+++ b/src/saga_action_func.rs
@@ -121,6 +121,7 @@ where
     >,
     ActionFuncOutput: ActionData,
 {
+    // TODO-log
     ActionFunc::new_action(f, |_| async { Ok(()) })
 }
 
@@ -136,10 +137,10 @@ where
     ActionFuncOutput: ActionData,
     for<'c> UndoFuncType: ActionFn<'c, UserType, Output = UndoResult>,
 {
-    fn do_it<'f>(
-        &'f self,
+    fn do_it(
+        &self,
         sgctx: ActionContext<UserType>,
-    ) -> BoxFuture<'f, ActionResult> {
+    ) -> BoxFuture<'_, ActionResult> {
         Box::pin(async move {
             let fut = self.action_func.act(sgctx);
             /*
@@ -155,10 +156,10 @@ where
         })
     }
 
-    fn undo_it<'f>(
-        &'f self,
+    fn undo_it(
+        &self,
         sgctx: ActionContext<UserType>,
-    ) -> BoxFuture<'f, UndoResult> {
+    ) -> BoxFuture<'_, UndoResult> {
         Box::pin(self.undo_func.act(sgctx))
     }
 }

--- a/src/saga_action_generic.rs
+++ b/src/saga_action_generic.rs
@@ -143,18 +143,12 @@ impl<UserType> Action<UserType> for ActionStartNode
 where
     UserType: SagaType,
 {
-    fn do_it(
-        &self,
-        _: ActionContext<UserType>,
-    ) -> BoxFuture<'_, ActionResult> {
+    fn do_it(&self, _: ActionContext<UserType>) -> BoxFuture<'_, ActionResult> {
         // TODO-log
         Box::pin(futures::future::ok(Arc::new(JsonValue::Null)))
     }
 
-    fn undo_it(
-        &self,
-        _: ActionContext<UserType>,
-    ) -> BoxFuture<'_, UndoResult> {
+    fn undo_it(&self, _: ActionContext<UserType>) -> BoxFuture<'_, UndoResult> {
         // TODO-log
         Box::pin(futures::future::ok(()))
     }
@@ -165,18 +159,12 @@ where
 pub struct ActionEndNode {}
 
 impl<UserType: SagaType> Action<UserType> for ActionEndNode {
-    fn do_it(
-        &self,
-        _: ActionContext<UserType>,
-    ) -> BoxFuture<'_, ActionResult> {
+    fn do_it(&self, _: ActionContext<UserType>) -> BoxFuture<'_, ActionResult> {
         // TODO-log
         Box::pin(futures::future::ok(Arc::new(JsonValue::Null)))
     }
 
-    fn undo_it(
-        &self,
-        _: ActionContext<UserType>,
-    ) -> BoxFuture<'_, UndoResult> {
+    fn undo_it(&self, _: ActionContext<UserType>) -> BoxFuture<'_, UndoResult> {
         /*
          * We should not run compensation actions for nodes that have not
          * started.  We should never start this node unless all other actions
@@ -192,18 +180,12 @@ impl<UserType: SagaType> Action<UserType> for ActionEndNode {
 pub struct ActionInjectError {}
 
 impl<UserType: SagaType> Action<UserType> for ActionInjectError {
-    fn do_it(
-        &self,
-        _: ActionContext<UserType>,
-    ) -> BoxFuture<'_, ActionResult> {
+    fn do_it(&self, _: ActionContext<UserType>) -> BoxFuture<'_, ActionResult> {
         // TODO-log
         Box::pin(futures::future::err(ActionError::InjectedError))
     }
 
-    fn undo_it(
-        &self,
-        _: ActionContext<UserType>,
-    ) -> BoxFuture<'_, UndoResult> {
+    fn undo_it(&self, _: ActionContext<UserType>) -> BoxFuture<'_, UndoResult> {
         /* We should never undo an action that failed. */
         unimplemented!();
     }

--- a/src/saga_action_generic.rs
+++ b/src/saga_action_generic.rs
@@ -117,18 +117,18 @@ pub trait Action<UserType: SagaType>: Debug + Send + Sync {
      * This is the _only_ supported means of sharing state across actions within
      * a saga.
      */
-    fn do_it<'f>(
-        &'f self,
+    fn do_it(
+        &self,
         sgctx: ActionContext<UserType>,
-    ) -> BoxFuture<'f, ActionResult>;
+    ) -> BoxFuture<'_, ActionResult>;
 
     /**
      * Executes the undo action for this saga node, whatever that is.
      */
-    fn undo_it<'f>(
-        &'f self,
+    fn undo_it(
+        &self,
         sgctx: ActionContext<UserType>,
-    ) -> BoxFuture<'f, UndoResult>;
+    ) -> BoxFuture<'_, UndoResult>;
 }
 
 /*
@@ -143,18 +143,18 @@ impl<UserType> Action<UserType> for ActionStartNode
 where
     UserType: SagaType,
 {
-    fn do_it<'f>(
-        &'f self,
+    fn do_it(
+        &self,
         _: ActionContext<UserType>,
-    ) -> BoxFuture<'f, ActionResult> {
+    ) -> BoxFuture<'_, ActionResult> {
         // TODO-log
         Box::pin(futures::future::ok(Arc::new(JsonValue::Null)))
     }
 
-    fn undo_it<'f>(
-        &'f self,
+    fn undo_it(
+        &self,
         _: ActionContext<UserType>,
-    ) -> BoxFuture<'f, UndoResult> {
+    ) -> BoxFuture<'_, UndoResult> {
         // TODO-log
         Box::pin(futures::future::ok(()))
     }
@@ -165,18 +165,18 @@ where
 pub struct ActionEndNode {}
 
 impl<UserType: SagaType> Action<UserType> for ActionEndNode {
-    fn do_it<'f>(
-        &'f self,
+    fn do_it(
+        &self,
         _: ActionContext<UserType>,
-    ) -> BoxFuture<'f, ActionResult> {
+    ) -> BoxFuture<'_, ActionResult> {
         // TODO-log
         Box::pin(futures::future::ok(Arc::new(JsonValue::Null)))
     }
 
-    fn undo_it<'f>(
-        &'f self,
+    fn undo_it(
+        &self,
         _: ActionContext<UserType>,
-    ) -> BoxFuture<'f, UndoResult> {
+    ) -> BoxFuture<'_, UndoResult> {
         /*
          * We should not run compensation actions for nodes that have not
          * started.  We should never start this node unless all other actions
@@ -192,18 +192,18 @@ impl<UserType: SagaType> Action<UserType> for ActionEndNode {
 pub struct ActionInjectError {}
 
 impl<UserType: SagaType> Action<UserType> for ActionInjectError {
-    fn do_it<'f>(
-        &'f self,
+    fn do_it(
+        &self,
         _: ActionContext<UserType>,
-    ) -> BoxFuture<'f, ActionResult> {
+    ) -> BoxFuture<'_, ActionResult> {
         // TODO-log
         Box::pin(futures::future::err(ActionError::InjectedError))
     }
 
-    fn undo_it<'f>(
-        &'f self,
+    fn undo_it(
+        &self,
         _: ActionContext<UserType>,
-    ) -> BoxFuture<'f, UndoResult> {
+    ) -> BoxFuture<'_, UndoResult> {
         /* We should never undo an action that failed. */
         unimplemented!();
     }


### PR DESCRIPTION
While it isn't apparent here, undoing the `async_trait` transform is in preparation for enabling context-by-reference. If that's not a thing you're excited about I can reapply `async_trait` (though it won't surprise you that I find things that hide heap allocations distasteful).

Most of the context is in the second commit, which I reproduce here:

---

This was intended to be a non-breaking change - I'd appreciate any info
to the contrary!

- Introduced ActionFn trait to wrap up the repeated stack of type
  constraints around async functions. (Better name suggestions welcome,
  would have called it ActionFunc, but ActionFunc is already a thing
  that is actually *two* funcs).

- With the Future and Output types now associated on the trait,
  eliminated the type parameters that used to model them.

- Removed unnecessary constraints (e.g. on the Debug impl) which were
  boilerplatey and open to rot.

I was tempted to make ActionFunc private, since users can't call any
operations on it or create an instance that isn't behind a Box dyn, but
I'm concerned that I don't understand why it's pub and I'm worried that
would be a breaking change.