### PR TITLE
Adhere to the consuming builder pattern for SagaTemplateBuilder

### DIFF
--- a/examples/trip.rs
+++ b/examples/trip.rs
@@ -115,7 +115,7 @@ async fn book_trip(trip_context: Arc<TripContext>, params: TripParams) {
 /// that are part of the saga (including the functions to be invoked to do each
 /// of the steps) and how they depend on each other.
 fn make_trip_saga() -> SagaTemplate<TripSaga> {
-    let mut builder = SagaTemplateBuilder::new();
+    let builder = SagaTemplateBuilder::new();
 
     //
     // Somewhat arbitrarily, we're choosing to charge the credit card first,
@@ -124,38 +124,37 @@ fn make_trip_saga() -> SagaTemplate<TripSaga> {
     // Steno guarantees that eventually either all actions will succeed or all
     // executed actions will be undone.
     //
-    builder.append(
-        // name of this action's output (can be used in subsequent actions)
-        "payment",
-        // human-readable label for the action
-        "ChargeCreditCard",
-        ActionFunc::new_action(
-            // action function
-            saga_charge_card,
-            // undo function
-            saga_refund_card,
-        ),
-    );
-
-    builder.append_parallel(vec![
-        (
-            "hotel",
-            "BookHotel",
-            ActionFunc::new_action(saga_book_hotel, saga_cancel_hotel),
-        ),
-        (
-            "flight",
-            "BookFlight",
-            ActionFunc::new_action(saga_book_flight, saga_cancel_flight),
-        ),
-        (
-            "car",
-            "BookCar",
-            ActionFunc::new_action(saga_book_car, saga_cancel_car),
-        ),
-    ]);
-
-    builder.build()
+    builder
+        .append(
+            // name of this action's output (can be used in subsequent actions)
+            "payment",
+            // human-readable label for the action
+            "ChargeCreditCard",
+            ActionFunc::new_action(
+                // action function
+                saga_charge_card,
+                // undo function
+                saga_refund_card,
+            ),
+        )
+        .append_parallel(vec![
+            (
+                "hotel",
+                "BookHotel",
+                ActionFunc::new_action(saga_book_hotel, saga_cancel_hotel),
+            ),
+            (
+                "flight",
+                "BookFlight",
+                ActionFunc::new_action(saga_book_flight, saga_cancel_flight),
+            ),
+            (
+                "car",
+                "BookCar",
+                ActionFunc::new_action(saga_book_car, saga_cancel_car),
+            ),
+        ])
+        .build()
 }
 
 //

--- a/src/example_provision.rs
+++ b/src/example_provision.rs
@@ -85,47 +85,47 @@ impl From<ExampleError> for ActionError {
  * using the `demo-provision` example.
  */
 pub fn make_example_provision_saga() -> Arc<SagaTemplate<ExampleSagaType>> {
-    let mut w = SagaTemplateBuilder::new();
-
-    w.append(
-        "instance_id",
-        "InstanceCreate",
-        new_action_noop_undo(demo_prov_instance_create),
-    );
-    w.append_parallel(vec![
-        (
-            "instance_ip",
-            "VpcAllocIp",
-            new_action_noop_undo(demo_prov_vpc_alloc_ip),
-        ),
-        (
-            "volume_id",
-            "VolumeCreate",
-            new_action_noop_undo(demo_prov_volume_create),
-        ),
-        (
-            "server_id",
-            "ServerAlloc (subsaga)",
-            new_action_noop_undo(demo_prov_server_alloc),
-        ),
-    ]);
-    w.append(
-        "instance_configure",
-        "InstanceConfigure",
-        new_action_noop_undo(demo_prov_instance_configure),
-    );
-    w.append(
-        "volume_attach",
-        "VolumeAttach",
-        new_action_noop_undo(demo_prov_volume_attach),
-    );
-    w.append(
-        "instance_boot",
-        "InstanceBoot",
-        new_action_noop_undo(demo_prov_instance_boot),
-    );
-    w.append("print", "Print", new_action_noop_undo(demo_prov_print));
-    Arc::new(w.build())
+    let saga = SagaTemplateBuilder::new()
+        .append(
+            "instance_id",
+            "InstanceCreate",
+            new_action_noop_undo(demo_prov_instance_create),
+        )
+        .append_parallel(vec![
+            (
+                "instance_ip",
+                "VpcAllocIp",
+                new_action_noop_undo(demo_prov_vpc_alloc_ip),
+            ),
+            (
+                "volume_id",
+                "VolumeCreate",
+                new_action_noop_undo(demo_prov_volume_create),
+            ),
+            (
+                "server_id",
+                "ServerAlloc (subsaga)",
+                new_action_noop_undo(demo_prov_server_alloc),
+            ),
+        ])
+        .append(
+            "instance_configure",
+            "InstanceConfigure",
+            new_action_noop_undo(demo_prov_instance_configure),
+        )
+        .append(
+            "volume_attach",
+            "VolumeAttach",
+            new_action_noop_undo(demo_prov_volume_attach),
+        )
+        .append(
+            "instance_boot",
+            "InstanceBoot",
+            new_action_noop_undo(demo_prov_instance_boot),
+        )
+        .append("print", "Print", new_action_noop_undo(demo_prov_print))
+        .build();
+    Arc::new(saga)
 }
 
 async fn demo_prov_instance_create(
@@ -175,18 +175,19 @@ async fn demo_prov_server_alloc(
 ) -> ExFuncResult<u64> {
     eprintln!("running action: {}", sgctx.node_label());
 
-    let mut w = SagaTemplateBuilder::new();
-    w.append(
-        "server_id",
-        "ServerPick",
-        new_action_noop_undo(demo_prov_server_pick),
-    );
-    w.append(
-        "server_reserve",
-        "ServerReserve",
-        new_action_noop_undo(demo_prov_server_reserve),
-    );
-    let sg = Arc::new(w.build());
+    let saga = SagaTemplateBuilder::new()
+        .append(
+            "server_id",
+            "ServerPick",
+            new_action_noop_undo(demo_prov_server_pick),
+        )
+        .append(
+            "server_reserve",
+            "ServerReserve",
+            new_action_noop_undo(demo_prov_server_reserve),
+        )
+        .build();
+    let sg = Arc::new(saga);
 
     /*
      * The uuid here is deterministic solely for the smoke tests.  It would

--- a/src/saga_template.rs
+++ b/src/saga_template.rs
@@ -209,11 +209,11 @@ impl<UserType: SagaType> SagaTemplateBuilder<UserType> {
      * [`crate::ActionContext::lookup`].
      */
     pub fn append(
-        &mut self,
+        mut self,
         name: &str,
         label: &str,
         action: Arc<dyn Action<UserType>>,
-    ) {
+    ) -> Self {
         let newnode = self.graph.add_node(label.to_string());
         self.launchers
             .insert(newnode, action)
@@ -230,6 +230,7 @@ impl<UserType: SagaType> SagaTemplateBuilder<UserType> {
         }
 
         self.last_added = vec![newnode];
+        self
     }
 
     /**
@@ -241,9 +242,9 @@ impl<UserType: SagaType> SagaTemplateBuilder<UserType> {
      * [`SagaTemplateBuilder::append`].
      */
     pub fn append_parallel(
-        &mut self,
+        mut self,
         actions: Vec<(&str, &str, Arc<dyn Action<UserType>>)>,
-    ) {
+    ) -> Self {
         let newnodes: Vec<NodeIndex> = actions
             .into_iter()
             .map(|(n, l, a)| {
@@ -284,6 +285,7 @@ impl<UserType: SagaType> SagaTemplateBuilder<UserType> {
         }
 
         self.last_added = newnodes;
+        self
     }
 
     /** Finishes building the saga template */


### PR DESCRIPTION
For context, see: https://doc.rust-lang.org/1.0.0/style/ownership/builders.html

TL;DR: there are two patterns of builders that are common in Rust.

# Non-Consuming

- `append` (and `append_parallel`) would act on a `&mut self` and return `&mut self`. This allows chaining.
- `build` would act on a `&mut self` and return a `SagaTemplate<UserType>`. This allows chaining, but does not consume the builder on creation.

# Consuming

- `append` (and `append_parallel`) would act on a `mut self` and return `mut self`. This allows chaining.
- `build` would act on a `mut self` and return a `SagaTemplate<UserType>`. This allows chaining while consuming the builder on creation.


This PR updates the `SagaTemplateBuilder` to be a "chainable, consuming builder" - I chose "consuming" based on the current signature to `build`, which consumes `mut self`, though the non-consuming variant would also be possible if this was relaxed to `&mut self`.