### PR TITLE
Use Default derive and allow dead_code on currently unused field to make clippy lint check happy.

### DIFF
--- a/src/example_provision.rs
+++ b/src/example_provision.rs
@@ -53,13 +53,8 @@ pub struct ExampleParams {
     pub instance_name: String,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct ExampleContext;
-impl Default for ExampleContext {
-    fn default() -> ExampleContext {
-        ExampleContext {}
-    }
-}
 
 type SagaExampleContext = ActionContext<ExampleSagaType>;
 

--- a/src/saga_exec.rs
+++ b/src/saga_exec.rs
@@ -346,9 +346,6 @@ pub struct SagaExecutor<UserType: SagaType> {
     #[allow(dead_code)]
     log: slog::Logger,
 
-    // TODO This could probably be a reference instead.
-    #[allow(dead_code)]
-    saga_template: Arc<SagaTemplate<UserType>>,
     saga_metadata: Arc<SagaTemplateMetadata>,
 
     /** Channel for monitoring execution completion */
@@ -637,7 +634,6 @@ impl<UserType: SagaType> SagaExecutor<UserType> {
 
         Ok(SagaExecutor {
             log,
-            saga_template,
             saga_metadata,
             finish_tx,
             saga_id,

--- a/src/saga_exec.rs
+++ b/src/saga_exec.rs
@@ -343,9 +343,11 @@ struct TaskParams<UserType: SagaType> {
  */
 #[derive(Debug)]
 pub struct SagaExecutor<UserType: SagaType> {
+    #[allow(dead_code)]
     log: slog::Logger,
 
     // TODO This could probably be a reference instead.
+    #[allow(dead_code)]
     saga_template: Arc<SagaTemplate<UserType>>,
     saga_metadata: Arc<SagaTemplateMetadata>,
 


### PR DESCRIPTION
The clippy check was failing in CI due to some unused fields and derivable-Default impl.