### PR TITLE
Add Dag::builder method

### DIFF
--- a/src/dag.rs
+++ b/src/dag.rs
@@ -537,6 +537,13 @@ enum DagBuilderErrorKind {
     EmptyStage,
 }
 
+impl Dag {
+    /// Creates a new [`DagBuilder`] instance.
+    pub fn builder(saga_name: SagaName) -> DagBuilder {
+        DagBuilder::new(saga_name)
+    }
+}
+
 impl DagBuilder {
     /// Begin building a DAG for a saga or subsaga
     pub fn new(saga_name: SagaName) -> DagBuilder {


### PR DESCRIPTION
It's common in Rust when you have both a type and builder for that type, to add a constructor named `builder` to the original type. This shortens creating new builders, and also means that you often don't have to import both the type and the builder.

```rust
// Previous
steno::DagBuilder::new("saga_name")
// After
steno::Dag::builder("saga_name")
```