### PR TITLE
prepare for next release

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,6 +15,9 @@
 
 https://github.com/oxidecomputer/steno/compare/v0.2.0\...HEAD[Full list of commits]
 
+* https://github.com/oxidecomputer/steno/pull/40[#40] Add `Dag::builder` method
+* https://github.com/oxidecomputer/steno/pull/67[#67] Add methods for inspecting Saga DAG / https://github.com/oxidecomputer/steno/pull/73[#73] A minor extention to #67, expose indices
+
 === Breaking Changes
 
 None.

--- a/release.toml
+++ b/release.toml
@@ -2,14 +2,14 @@
 # This version is cribbed from Dropshot and updated for cargo-release 0.21.1
 
 # Update the change log to reflect the new release and set us up for the next release.
-#pre-release-replacements = [
-#  # First, replace the current "Unreleased changes" header with one reflecting the new release version and date.
-#  {file="CHANGELOG.adoc", search="Unreleased changes \\(release date TBD\\)", replace="{{version}} (released {{date}})", exactly=1},
-#  # Update the link to the list of raw commits in the formerly "Unreleased changes" section.  It should end at the tag for the newly-released version.
-#  {file="CHANGELOG.adoc", search="\\\\.\\.\\.HEAD", replace="\\...{{tag_name}}", exactly=1},
-#  # Next, append a new "Unreleased changes" header beneath the sentinel line.
-#  {file="CHANGELOG.adoc", search="// cargo-release: next header goes here \\(do not change this line\\)", replace="// cargo-release: next header goes here (do not change this line)\n\n== Unreleased changes (release date TBD)\n\nhttps://github.com/oxidecomputer/steno/compare/{{tag_name}}\\...HEAD[Full list of commits]", exactly=1},
-#]
+pre-release-replacements = [
+  # First, replace the current "Unreleased changes" header with one reflecting the new release version and date.
+  {file="CHANGELOG.adoc", search="Unreleased changes \\(release date TBD\\)", replace="{{version}} (released {{date}})", exactly=1},
+  # Update the link to the list of raw commits in the formerly "Unreleased changes" section.  It should end at the tag for the newly-released version.
+  {file="CHANGELOG.adoc", search="\\\\.\\.\\.HEAD", replace="\\...{{tag_name}}", exactly=1},
+  # Next, append a new "Unreleased changes" header beneath the sentinel line.
+  {file="CHANGELOG.adoc", search="// cargo-release: next header goes here \\(do not change this line\\)", replace="// cargo-release: next header goes here (do not change this line)\n\n== Unreleased changes (release date TBD)\n\nhttps://github.com/oxidecomputer/steno/compare/{{tag_name}}\\...HEAD[Full list of commits]", exactly=1},
+]
 
 push = false
 pre-release-commit-message = "release {{crate_name}} {{version}}"


### PR DESCRIPTION
This PR updates the changelog for recent changes and also updates the release.toml file to update the changelog with each release.  (This latter bit was an oversight in #34.)