### PR TITLE
impl `Default` for `ActionRegistry`

### DIFF
--- a/src/dag.rs
+++ b/src/dag.rs
@@ -187,6 +187,12 @@ impl<UserType: SagaType> ActionRegistry<UserType> {
     }
 }
 
+impl<UserType: SagaType> ActionRegistry<UserType> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Describes a node in the saga DAG
 ///
 /// There are three kinds of nodes you can add to a graph:

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -187,7 +187,7 @@ impl<UserType: SagaType> ActionRegistry<UserType> {
     }
 }
 
-impl<UserType: SagaType> ActionRegistry<UserType> {
+impl<UserType: SagaType> Default for ActionRegistry<UserType> {
     fn default() -> Self {
         Self::new()
     }


### PR DESCRIPTION
Since `ActionRegistry`'s `new` constructor accept no arguments, it's typically considered best practice for it to implement `Default`.