### PR TITLE
better handle undo actions that fail

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,13 +33,11 @@ jobs:
       run: cargo clippy -- --version
     - name: Run Clippy Lints
       #
-      # Clippy overrides should go into src/lib.rs so that developers running
-      # `cargo clippy` see the same behavior as we see here in the GitHub
-      # Action.  In some cases, the overrides also need to appear here because
-      # clippy does not always honor the crate-wide overrides.  See
-      # rust-lang/rust-clippy#6610.
+      # Clippy's style nits are useful, but not worth keeping in CI.  This
+      # override belongs in src/lib.rs, and it is there, but that doesn't
+      # reliably work due to rust-lang/rust-clippy#6610.
       #
-      run: cargo clippy -- -A clippy::style -D warnings
+      run: cargo clippy --all-targets -- --deny warnings --allow clippy::style
 
   build-and-test:
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,6 +15,10 @@
 
 https://github.com/oxidecomputer/steno/compare/v0.3.1\...HEAD[Full list of commits]
 
+=== Breaking changes
+
+* https://github.com/oxidecomputer/steno/pull/138[#138] Steno no longer panics when an undo action fails.  `SagaResultErr` has a new optional field describing whether any undo action failed during unwinding.  **You should check this.**  If an undo action fails, then the program has failed to provide the usual guarantee that a saga either runs to completion or completely unwinds.  What to do next is application-specific but in general this cannot be automatically recovered from.  (If there are steps that can automatically recover in this case, the undo action that failed should probably do that instead.)
+
 == 0.3.1 (released 2023-01-06)
 
 https://github.com/oxidecomputer/steno/compare/v0.3.0\...v0.3.1[Full list of commits]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -910,7 +910,7 @@ dependencies = [
 
 [[package]]
 name = "steno"
-version = "0.3.2-dev"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -910,7 +910,7 @@ dependencies = [
 
 [[package]]
 name = "steno"
-version = "0.4.0"
+version = "0.4.0-dev"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "steno"
-version = "0.3.2-dev"
+version = "0.4.0" # XXX-dap
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/oxidecomputer/steno"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "steno"
-version = "0.4.0" # XXX-dap
+version = "0.4.0-dev"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/oxidecomputer/steno"

--- a/examples/trip.rs
+++ b/examples/trip.rs
@@ -21,6 +21,7 @@ use steno::Node;
 use steno::SagaDag;
 use steno::SagaId;
 use steno::SagaName;
+use steno::SagaResultErr;
 use steno::SagaType;
 use steno::SecClient;
 use uuid::Uuid;
@@ -116,9 +117,14 @@ async fn book_trip(
             );
             println!("\nraw summary:\n{:?}", success.saga_output::<Summary>());
         }
-        Err(error) => {
-            println!("action failed: {}", error.error_node_name.as_ref());
-            println!("error: {}", error.error_source);
+        Err(SagaResultErr { error_node_name, error_source, undo_failure }) => {
+            println!("action failed: {}", error_node_name.as_ref());
+            println!("error: {}", error_source);
+            if let Some((undo_node_name, undo_error_source)) = undo_failure {
+                println!("additionally:");
+                println!("undo action failed: {}", undo_node_name.as_ref());
+                println!("error: {}", undo_error_source);
+            }
         }
     }
 }

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -1060,7 +1060,7 @@ mod test {
         builder.append(Node::constant("a", serde_json::Value::Null));
         builder.append_parallel(vec![
             Node::constant("c", serde_json::Value::Null),
-            Node::subsaga("b", subsaga_dag.clone(), "c"),
+            Node::subsaga("b", subsaga_dag, "c"),
         ]);
         let error = builder.build().unwrap_err();
         println!("{:?}", error);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@ pub use dag::SagaDag;
 pub use dag::SagaId;
 pub use dag::SagaName;
 pub use saga_action_error::ActionError;
+pub use saga_action_error::UndoActionError;
 pub use saga_action_func::new_action_noop_undo;
 pub use saga_action_func::ActionFunc;
 pub use saga_action_func::ActionFuncResult;

--- a/src/saga_action_error.rs
+++ b/src/saga_action_error.rs
@@ -144,6 +144,16 @@ impl ActionError {
 }
 
 /// An error produced by a failed undo action
+///
+/// **Returning an error from an undo action should be avoided if at all
+/// possible.**  If undo actions experience transient issues, they should
+/// generally retry until the undo action completes successfully.  That's
+/// because by definition, failure of an undo action means that the saga's
+/// actions cannot be unwound.  The system cannot move forward to the desired
+/// saga end state nor backward to the initial state.  It's left forever in some
+/// partially-updated state.  This should really only happen because of a bug.
+/// It should be expected that human intervention will be required to repair the
+/// result of an undo action that has failed.
 #[derive(Clone, Debug, Deserialize, Error, JsonSchema, Serialize)]
 pub enum UndoActionError {
     /// Undo action failed due to a consumer-specific error

--- a/src/saga_action_error.rs
+++ b/src/saga_action_error.rs
@@ -142,3 +142,11 @@ impl ActionError {
         ActionError::SubsagaCreateFailed { message }
     }
 }
+
+/// An error produced by a failed undo action
+#[derive(Clone, Debug, Deserialize, Error, JsonSchema, Serialize)]
+pub enum UndoActionError {
+    /// Undo action failed due to a consumer-specific error
+    #[error("undo action failed permanently: {source_error:#}")]
+    PermanentFailure { source_error: serde_json::Value },
+}

--- a/src/saga_action_generic.rs
+++ b/src/saga_action_generic.rs
@@ -167,7 +167,7 @@ impl<UserType: SagaType> Action<UserType> for ActionInjectError {
     fn undo_it(&self, _: ActionContext<UserType>) -> BoxFuture<'_, UndoResult> {
         // We should never undo an action that failed.  But this same impl is
         // plugged into a saga when an "undo action" error is injected.
-        Box::pin(futures::future::err(anyhow::anyhow!("injected error")))
+        Box::pin(futures::future::err(anyhow::anyhow!("error injected")))
     }
 
     fn name(&self) -> ActionName {

--- a/src/saga_action_generic.rs
+++ b/src/saga_action_generic.rs
@@ -165,8 +165,9 @@ impl<UserType: SagaType> Action<UserType> for ActionInjectError {
     }
 
     fn undo_it(&self, _: ActionContext<UserType>) -> BoxFuture<'_, UndoResult> {
-        // We should never undo an action that failed.
-        unimplemented!();
+        // But this same impl is plugged into a saga when an "undo action" error
+        // is injected.
+        Box::pin(futures::future::err(anyhow::anyhow!("injected error")))
     }
 
     fn name(&self) -> ActionName {

--- a/src/saga_action_generic.rs
+++ b/src/saga_action_generic.rs
@@ -165,8 +165,8 @@ impl<UserType: SagaType> Action<UserType> for ActionInjectError {
     }
 
     fn undo_it(&self, _: ActionContext<UserType>) -> BoxFuture<'_, UndoResult> {
-        // But this same impl is plugged into a saga when an "undo action" error
-        // is injected.
+        // We should never undo an action that failed.  But this same impl is
+        // plugged into a saga when an "undo action" error is injected.
         Box::pin(futures::future::err(anyhow::anyhow!("injected error")))
     }
 

--- a/src/saga_exec.rs
+++ b/src/saga_exec.rs
@@ -292,7 +292,6 @@ impl<UserType: SagaType> SagaNodeRest<UserType> for SagaNode<SgnsUndoFailed> {
         live_state: &mut SagaExecLiveState,
     ) {
         assert!(live_state.exec_state == SagaCachedState::Unwinding);
-        assert!(!live_state.undo_errors.contains_key(&self.node_id));
         live_state
             .undo_errors
             .insert(self.node_id, self.state.0.clone())
@@ -670,7 +669,6 @@ impl<UserType: SagaType> SagaExecutor<UserType> {
                 }
                 SagaNodeLoadStatus::UndoFailed(error) => {
                     assert!(!forward);
-                    assert!(!live_state.undo_errors.contains_key(&node_id));
                     live_state
                         .undo_errors
                         .insert(node_id, error.clone())

--- a/src/saga_exec.rs
+++ b/src/saga_exec.rs
@@ -1000,8 +1000,6 @@ impl<UserType: SagaType> SagaExecutor<UserType> {
             }
         }
 
-        // XXX-dap
-        // - review all places where we check SagaCachedState::Done
         let live_state = self.live_state.try_lock().unwrap();
         assert!(
             live_state.exec_state == SagaCachedState::Done

--- a/src/saga_log.rs
+++ b/src/saga_log.rs
@@ -1,6 +1,7 @@
 //! Persistent state for sagas
 
 use crate::saga_action_error::ActionError;
+use crate::saga_action_error::UndoActionError;
 use crate::SagaId;
 use anyhow::anyhow;
 use anyhow::Context;
@@ -85,7 +86,7 @@ pub enum SagaNodeEventType {
     /// The undo action has finished
     UndoFinished,
     /// The undo action has failed
-    UndoFailed(Arc<serde_json::Value>),
+    UndoFailed(UndoActionError),
 }
 
 impl fmt::Display for SagaNodeEventType {
@@ -132,7 +133,7 @@ pub enum SagaNodeLoadStatus {
     /// The undo action has finished successfully
     UndoFinished,
     /// The undo action has failed
-    UndoFailed(Arc<serde_json::Value>),
+    UndoFailed(UndoActionError),
 }
 
 impl SagaNodeLoadStatus {
@@ -163,7 +164,7 @@ impl SagaNodeLoadStatus {
             (
                 SagaNodeLoadStatus::UndoStarted(_),
                 SagaNodeEventType::UndoFailed(e),
-            ) => Ok(SagaNodeLoadStatus::UndoFailed(Arc::clone(e))),
+            ) => Ok(SagaNodeLoadStatus::UndoFailed(e.clone())),
             _ => Err(SagaLogError::IllegalEventForState {
                 current_status: self.clone(),
                 event_type: event_type.clone(),

--- a/src/store.rs
+++ b/src/store.rs
@@ -67,6 +67,7 @@ pub struct SagaCreateParams {
 pub enum SagaCachedState {
     Running,
     Unwinding,
+    Stuck,
     Done,
 }
 
@@ -93,6 +94,7 @@ impl<'a> From<&'a SagaCachedState> for &'a str {
         match s {
             SagaCachedState::Running => "running",
             SagaCachedState::Unwinding => "unwinding",
+            SagaCachedState::Stuck => "stuck",
             SagaCachedState::Done => "done",
         }
     }

--- a/src/store.rs
+++ b/src/store.rs
@@ -67,7 +67,6 @@ pub struct SagaCreateParams {
 pub enum SagaCachedState {
     Running,
     Unwinding,
-    Stuck,
     Done,
 }
 
@@ -94,7 +93,6 @@ impl<'a> From<&'a SagaCachedState> for &'a str {
         match s {
             SagaCachedState::Running => "running",
             SagaCachedState::Unwinding => "unwinding",
-            SagaCachedState::Stuck => "stuck",
             SagaCachedState::Done => "done",
         }
     }

--- a/tests/test_smoke.rs
+++ b/tests/test_smoke.rs
@@ -72,6 +72,18 @@ fn cmd_run_error() {
 }
 
 #[test]
+fn cmd_run_stuck() {
+    assert_contents(
+        "tests/test_smoke_run_stuck.out",
+        &run_example("run_stuck", |exec| {
+            exec.arg("run")
+                .arg("--inject-error=instance_boot")
+                .arg("--inject-undo-error=instance_ip")
+        }),
+    );
+}
+
+#[test]
 fn cmd_run_recover() {
     // Do a normal run and save the log so we can try recovering from it.
     let log = run_example("recover1", |exec| {

--- a/tests/test_smoke.rs
+++ b/tests/test_smoke.rs
@@ -78,7 +78,7 @@ fn cmd_run_stuck() {
         &run_example("run_stuck", |exec| {
             exec.arg("run")
                 .arg("--inject-error=instance_boot")
-                .arg("--inject-undo-error=instance_ip")
+                .arg("--inject-undo-error=instance_id")
         }),
     );
 }

--- a/tests/test_smoke.rs
+++ b/tests/test_smoke.rs
@@ -148,3 +148,24 @@ fn cmd_run_recover_unwind() {
         }),
     );
 }
+
+#[test]
+fn cmd_run_recover_stuck() {
+    // Do a failed run and save the log so we can try recovering from it.
+    let log = run_example("recover_stuck1", |exec| {
+        exec.arg("run")
+            .arg("--dump-to=-")
+            .arg("--quiet")
+            .arg("--inject-error=instance_boot")
+            .arg("--inject-undo-error=instance_id")
+    });
+
+    // First, try recovery without having changed anything.
+    let recovery_done = run_example("recover_stuck2", |exec| {
+        exec.arg("run").arg("--recover-from=-").stdin(log.as_str())
+    });
+    assert_contents(
+        "tests/test_smoke_run_recover_stuck_done.out",
+        &recovery_done,
+    );
+}

--- a/tests/test_smoke_run_recover_fail_done.out
+++ b/tests/test_smoke_run_recover_fail_done.out
@@ -39,6 +39,6 @@ recovered state
 +-- abandoned: Print (produces "print")
 +-- abandoned: (end node)
 
-result: FAILURE
+result: ACTION FAILURE
 failed at node:    "instance_boot"
 failed with error: error injected

--- a/tests/test_smoke_run_recover_fail_some.out
+++ b/tests/test_smoke_run_recover_fail_some.out
@@ -39,6 +39,6 @@ recovered state
 +-- abandoned: Print (produces "print")
 +-- abandoned: (end node)
 
-result: FAILURE
+result: ACTION FAILURE
 failed at node:    "instance_boot"
 failed with error: error injected

--- a/tests/test_smoke_run_recover_stuck_done.out
+++ b/tests/test_smoke_run_recover_stuck_done.out
@@ -45,5 +45,5 @@ failed with error: error injected
 FOLLOWED BY UNDO ACTION FAILURE
 failed at node:    "instance_id"
 failed with error: undo action failed permanently: {
-  "message": "undo action attempt 1: injected error"
+  "message": "undo action attempt 1: error injected"
 }

--- a/tests/test_smoke_run_recover_stuck_done.out
+++ b/tests/test_smoke_run_recover_stuck_done.out
@@ -1,5 +1,23 @@
-will inject error at node "instance_boot"
-will inject error at node "instance_id" undo action
+recovering from log: -
+recovered state
++ saga execution: 049b2522-308d-442e-bc65-9bfaef863597
++-- done: (start node)
++-- undo-failed: InstanceCreate (produces "instance_id")
++-- undone: (constant = {"number_of_things":1}) (produces "server_alloc_params")
++-- (parallel actions):
+        +-- undone: VpcAllocIp (produces "instance_ip")
+        +-- undone: VolumeCreate (produces "volume_id")
+        +-- undone: (subsaga start: "server-alloc")
+                +-- undone: ServerPick (produces "server_id")
+                +-- undone: ServerReserve (produces "server_reserve")
+        +-- undone: (subsaga end) (produces "server_alloc")
++-- undone: InstanceConfigure (produces "instance_configure")
++-- undone: VolumeAttach (produces "volume_attach")
++-- failed: InstanceBoot (produces "instance_boot")
++-- abandoned: Print (produces "print")
++-- abandoned: (end node)
+
+
 *** running saga ***
 *** finished saga ***
 

--- a/tests/test_smoke_run_stuck.out
+++ b/tests/test_smoke_run_stuck.out
@@ -27,5 +27,5 @@ failed with error: error injected
 FOLLOWED BY UNDO ACTION FAILURE
 failed at node:    "instance_id"
 failed with error: undo action failed permanently: {
-  "message": "undo action attempt 1: injected error"
+  "message": "undo action attempt 1: error injected"
 }

--- a/tests/test_smoke_run_stuck.out
+++ b/tests/test_smoke_run_stuck.out
@@ -1,18 +1,19 @@
 will inject error at node "instance_boot"
+will inject error at node "instance_ip" undo action
 *** running saga ***
 *** finished saga ***
 
 *** final state ***
 + saga execution: 049b2522-308d-442e-bc65-9bfaef863597
-+-- undone: (start node)
-+-- undone: InstanceCreate (produces "instance_id")
-+-- undone: (constant = {"number_of_things":1}) (produces "server_alloc_params")
++-- done: (start node)
++-- done: InstanceCreate (produces "instance_id")
++-- done: (constant = {"number_of_things":1}) (produces "server_alloc_params")
 +-- (parallel actions):
-        +-- undone: VpcAllocIp (produces "instance_ip")
+        +-- done: VpcAllocIp (produces "instance_ip")
         +-- undone: VolumeCreate (produces "volume_id")
-        +-- undone: (subsaga start: "server-alloc")
-                +-- undone: ServerPick (produces "server_id")
-                +-- undone: ServerReserve (produces "server_reserve")
+        +-- done: (subsaga start: "server-alloc")
+                +-- done: ServerPick (produces "server_id")
+                +-- done: ServerReserve (produces "server_reserve")
         +-- undone: (subsaga end) (produces "server_alloc")
 +-- undone: InstanceConfigure (produces "instance_configure")
 +-- undone: VolumeAttach (produces "volume_attach")
@@ -23,3 +24,8 @@ will inject error at node "instance_boot"
 result: ACTION FAILURE
 failed at node:    "instance_boot"
 failed with error: error injected
+FOLLOWED BY UNDO ACTION FAILURE
+failed at node:    "instance_ip"
+failed with error: undo action failed permanently: {
+  "message": "undo action attempt 1: injected error"
+}

--- a/tests/test_smoke_run_stuck.out
+++ b/tests/test_smoke_run_stuck.out
@@ -1,5 +1,5 @@
 will inject error at node "instance_boot"
-will inject error at node "instance_ip" undo action
+will inject error at node "instance_id" undo action
 *** running saga ***
 *** finished saga ***
 
@@ -7,13 +7,13 @@ will inject error at node "instance_ip" undo action
 + saga execution: 049b2522-308d-442e-bc65-9bfaef863597
 +-- done: (start node)
 +-- done: InstanceCreate (produces "instance_id")
-+-- done: (constant = {"number_of_things":1}) (produces "server_alloc_params")
++-- undone: (constant = {"number_of_things":1}) (produces "server_alloc_params")
 +-- (parallel actions):
-        +-- done: VpcAllocIp (produces "instance_ip")
+        +-- undone: VpcAllocIp (produces "instance_ip")
         +-- undone: VolumeCreate (produces "volume_id")
-        +-- done: (subsaga start: "server-alloc")
-                +-- done: ServerPick (produces "server_id")
-                +-- done: ServerReserve (produces "server_reserve")
+        +-- undone: (subsaga start: "server-alloc")
+                +-- undone: ServerPick (produces "server_id")
+                +-- undone: ServerReserve (produces "server_reserve")
         +-- undone: (subsaga end) (produces "server_alloc")
 +-- undone: InstanceConfigure (produces "instance_configure")
 +-- undone: VolumeAttach (produces "volume_attach")
@@ -25,7 +25,7 @@ result: ACTION FAILURE
 failed at node:    "instance_boot"
 failed with error: error injected
 FOLLOWED BY UNDO ACTION FAILURE
-failed at node:    "instance_ip"
+failed at node:    "instance_id"
 failed with error: undo action failed permanently: {
   "message": "undo action attempt 1: injected error"
 }


### PR DESCRIPTION
For background, see #26.  This is a first step towards resolving that.  The basic plan here is that if an undo action fails, then the executor will stop dispatching any new tasks, wait for any outstanding tasks to complete, and then come to rest.  The result looks similar to what happens if the saga finishes.  You can tell from the result type (see `SagaResultErr`) whether this is what happened.

For an example, see the output from the new smoke test.

I wrestled a little bit about whether "Stuck" should be a new terminal state (separate from "Done").  I tried that at first but it just made the code trickier and wasn't adding anything.  It may make sense to separate these better in the final View type but I figured let's see how this plays out in practice.

Here's what's still to-do here:

- [x] look at removing SagaCachedState::Stuck
- [x] add a test for recovering a stuck saga (but maybe this isn't meaningful if I do the above)
- [x] update the changelog
- [x] finish the Omicron side of the integration (oxidecomputer/omicron#3211)
- [x] get approval on this PR
- [x] get approval on Omicron PR (I'll probably wait to get both approvals before landing either one)
- [x] fix up the version number in Cargo.toml

After this, I think the remaining part of fixing #26 will be to change the return type for undo actions to `UndoActionError` so that callers are forced to write `UndoActionError::PermanentError`.  I hope that will guide people away from returning an error here out of convenience, since the impact of doing so is significant.