### PR TITLE
undo action error type could be more explicit (incomplete)

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,48 +17,13 @@ https://github.com/oxidecomputer/steno/compare/v0.4.0\...HEAD[Full list of commi
 
 === Breaking changes
 
-* The error type for undo actions is now called `UndoActionError`.  It used to be simply `anyhow::Error`.  `UndoActionError` is an enum that currently has only one variant called `PermanentFailure`, and it can be constructed from an `anyhow::Error` using `UndoActionError::permanent_failure(anyhow_error)`.
+* The error type for undo actions is now called `UndoActionPermanentError`.  It used to be simply `anyhow::Error`.  Steno's behavior when undo actions return an error has _not_ changed.  This explicit type was added to better communicate that if you return an error from an undo action, the saga will become stuck.  For convenience, there are `From` impls to produce an `UndoActionPermanentError` from an `anyhow::Error` or an `ActionError`.
 +
 **What you need to do:** For any function implementing an undo action:
 +
 ** If the return type was `Result<(), anyhow::Error>`, change it to `Result<(), UndoActionError>`.  If the return type was `UndoResult`, then you don't need to change the return type.
-** In the body of the function, any returned errors must be wrapped with `UndoActionError::permanent_failure`.
-*** If you were directly returning `Err(anyhow!("some message"))`, you can instead return `Err(UndoActionError::permanent_failure(anyhow!("some message")))`.
-*** If you were doing something like `fallible_function().context("some message")?` to convert some _other_ error into an `anyhow::Error` with additional context and then return it, you can instead use `fallible_function().context("some message").map_err(UndoActionError::permanent_failure)?`
-+
-For example, if you had this with Steno 0.4:
-[source,rust]
-----
-async fn saga_cancel_car(
-    action_context: ActionContext<TripSaga>,
-) -> Result<(), anyhow::Error> {
-    // ...
-    let trip_context = action_context.user_data();
-    let confirmation: CarReservation = action_context
-        .lookup("car")
-	.context("looking up action's output")?;
-    // ... (make request to another service -- must not fail)
-    Ok(())
-}
-----
-+
-You'd change it to this:
-+
-[source,rust]
-----
-async fn saga_cancel_car(
-    action_context: ActionContext<TripSaga>,
-) -> Result<(), UndoActionError> {
-    // ...
-    let trip_context = action_context.user_data();
-    let confirmation: CarReservation = action_context
-        .lookup("car")
-	.context("looking up action's output")
-        .map_err(UndoActionError::permanent_failure)?;
-    // ... (make request to another service -- must not fail)
-    Ok(())
-}
-----
+*** If you were directly returning `Err(some_anyhow_error)`, you can instead return `Err(UndoActionPermanentError::from(some_anyhow_error))`.
+*** If you were returning an error using `foo()?` that was _not_ an `anyhow::Error` or an `ActionError`, you can generally use `foo().map_err(anyhow::Error::from).map_err(UndoActionPermanentError::from)`.  (Your error type must have been convertible to `anyhow::Error` for it to compile before.  Now you're explicitly converting it to that, and then to `UndoActionPermanentError`.)
 
 == 0.4.0 (released 2023-05-25)
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,6 +15,51 @@
 
 https://github.com/oxidecomputer/steno/compare/v0.4.0\...HEAD[Full list of commits]
 
+=== Breaking changes
+
+* The error type for undo actions is now called `UndoActionError`.  It used to be simply `anyhow::Error`.  `UndoActionError` is an enum that currently has only one variant called `PermanentFailure`, and it can be constructed from an `anyhow::Error` using `UndoActionError::permanent_failure(anyhow_error)`.
++
+**What you need to do:** For any function implementing an undo action:
++
+** If the return type was `Result<(), anyhow::Error>`, change it to `Result<(), UndoActionError>`.  If the return type was `UndoResult`, then you don't need to change the return type.
+** In the body of the function, any returned errors must be wrapped with `UndoActionError::permanent_failure`.
+*** If you were directly returning `Err(anyhow!("some message"))`, you can instead return `Err(UndoActionError::permanent_failure(anyhow!("some message")))`.
+*** If you were doing something like `fallible_function().context("some message")?` to convert some _other_ error into an `anyhow::Error` with additional context and then return it, you can instead use `fallible_function().context("some message").map_err(UndoActionError::permanent_failure)?`
++
+For example, if you had this with Steno 0.4:
+[source,rust]
+----
+async fn saga_cancel_car(
+    action_context: ActionContext<TripSaga>,
+) -> Result<(), anyhow::Error> {
+    // ...
+    let trip_context = action_context.user_data();
+    let confirmation: CarReservation = action_context
+        .lookup("car")
+	.context("looking up action's output")?;
+    // ... (make request to another service -- must not fail)
+    Ok(())
+}
+----
++
+You'd change it to this:
++
+[source,rust]
+----
+async fn saga_cancel_car(
+    action_context: ActionContext<TripSaga>,
+) -> Result<(), UndoActionError> {
+    // ...
+    let trip_context = action_context.user_data();
+    let confirmation: CarReservation = action_context
+        .lookup("car")
+	.context("looking up action's output")
+        .map_err(UndoActionError::permanent_failure)?;
+    // ... (make request to another service -- must not fail)
+    Ok(())
+}
+----
+
 == 0.4.0 (released 2023-05-25)
 
 https://github.com/oxidecomputer/steno/compare/v0.3.1\...v0.4.0[Full list of commits]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "steno"
-version = "0.4.1-dev"
+version = "0.5.0-dev"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "steno"
-version = "0.4.1-dev"
+version = "0.5.0-dev"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/oxidecomputer/steno"

--- a/examples/trip.rs
+++ b/examples/trip.rs
@@ -24,6 +24,7 @@ use steno::SagaName;
 use steno::SagaResultErr;
 use steno::SagaType;
 use steno::SecClient;
+use steno::UndoActionError;
 use uuid::Uuid;
 
 // This is where we're going: this program will collect payment and book a whole
@@ -283,12 +284,15 @@ async fn saga_charge_card(
 
 async fn saga_refund_card(
     action_context: ActionContext<TripSaga>,
-) -> Result<(), anyhow::Error> {
+) -> Result<(), UndoActionError> {
     // Fetch the payment confirmation.  The undo function is only ever invoked
     // after the action function has succeeded.  This node is called "payment",
     // so we fetch our own action's output by looking up the data for "payment".
     let trip_context = action_context.user_data();
-    let p: PaymentConfirmation = action_context.lookup("payment")?;
+    let p: PaymentConfirmation = action_context
+        .lookup("payment")
+        .map_err(anyhow::Error::from)
+        .map_err(UndoActionError::permanent_failure)?;
     // ... (make request to another service -- must not fail)
     Ok(())
 }
@@ -306,10 +310,13 @@ async fn saga_book_hotel(
 
 async fn saga_cancel_hotel(
     action_context: ActionContext<TripSaga>,
-) -> Result<(), anyhow::Error> {
+) -> Result<(), UndoActionError> {
     // ...
     let trip_context = action_context.user_data();
-    let confirmation: HotelReservation = action_context.lookup("hotel")?;
+    let confirmation: HotelReservation = action_context
+        .lookup("hotel")
+        .map_err(anyhow::Error::from)
+        .map_err(UndoActionError::permanent_failure)?;
     // ... (make request to another service -- must not fail)
     Ok(())
 }
@@ -327,10 +334,13 @@ async fn saga_book_flight(
 
 async fn saga_cancel_flight(
     action_context: ActionContext<TripSaga>,
-) -> Result<(), anyhow::Error> {
+) -> Result<(), UndoActionError> {
     // ...
     let trip_context = action_context.user_data();
-    let confirmation: FlightReservation = action_context.lookup("flight")?;
+    let confirmation: FlightReservation = action_context
+        .lookup("flight")
+        .map_err(anyhow::Error::from)
+        .map_err(UndoActionError::permanent_failure)?;
     // ... (make request to another service -- must not fail)
     Ok(())
 }
@@ -348,10 +358,13 @@ async fn saga_book_car(
 
 async fn saga_cancel_car(
     action_context: ActionContext<TripSaga>,
-) -> Result<(), anyhow::Error> {
+) -> Result<(), UndoActionError> {
     // ...
     let trip_context = action_context.user_data();
-    let confirmation: CarReservation = action_context.lookup("car")?;
+    let confirmation: CarReservation = action_context
+        .lookup("car")
+        .map_err(anyhow::Error::from)
+        .map_err(UndoActionError::permanent_failure)?;
     // ... (make request to another service -- must not fail)
     Ok(())
 }

--- a/examples/trip.rs
+++ b/examples/trip.rs
@@ -24,7 +24,7 @@ use steno::SagaName;
 use steno::SagaResultErr;
 use steno::SagaType;
 use steno::SecClient;
-use steno::UndoActionError;
+use steno::UndoActionPermanentError;
 use uuid::Uuid;
 
 // This is where we're going: this program will collect payment and book a whole
@@ -284,15 +284,12 @@ async fn saga_charge_card(
 
 async fn saga_refund_card(
     action_context: ActionContext<TripSaga>,
-) -> Result<(), UndoActionError> {
+) -> Result<(), UndoActionPermanentError> {
     // Fetch the payment confirmation.  The undo function is only ever invoked
     // after the action function has succeeded.  This node is called "payment",
     // so we fetch our own action's output by looking up the data for "payment".
     let trip_context = action_context.user_data();
-    let p: PaymentConfirmation = action_context
-        .lookup("payment")
-        .map_err(anyhow::Error::from)
-        .map_err(UndoActionError::permanent_failure)?;
+    let p: PaymentConfirmation = action_context.lookup("payment")?;
     // ... (make request to another service -- must not fail)
     Ok(())
 }
@@ -310,13 +307,10 @@ async fn saga_book_hotel(
 
 async fn saga_cancel_hotel(
     action_context: ActionContext<TripSaga>,
-) -> Result<(), UndoActionError> {
+) -> Result<(), UndoActionPermanentError> {
     // ...
     let trip_context = action_context.user_data();
-    let confirmation: HotelReservation = action_context
-        .lookup("hotel")
-        .map_err(anyhow::Error::from)
-        .map_err(UndoActionError::permanent_failure)?;
+    let confirmation: HotelReservation = action_context.lookup("hotel")?;
     // ... (make request to another service -- must not fail)
     Ok(())
 }
@@ -334,13 +328,10 @@ async fn saga_book_flight(
 
 async fn saga_cancel_flight(
     action_context: ActionContext<TripSaga>,
-) -> Result<(), UndoActionError> {
+) -> Result<(), UndoActionPermanentError> {
     // ...
     let trip_context = action_context.user_data();
-    let confirmation: FlightReservation = action_context
-        .lookup("flight")
-        .map_err(anyhow::Error::from)
-        .map_err(UndoActionError::permanent_failure)?;
+    let confirmation: FlightReservation = action_context.lookup("flight")?;
     // ... (make request to another service -- must not fail)
     Ok(())
 }
@@ -358,13 +349,10 @@ async fn saga_book_car(
 
 async fn saga_cancel_car(
     action_context: ActionContext<TripSaga>,
-) -> Result<(), UndoActionError> {
+) -> Result<(), UndoActionPermanentError> {
     // ...
     let trip_context = action_context.user_data();
-    let confirmation: CarReservation = action_context
-        .lookup("car")
-        .map_err(anyhow::Error::from)
-        .map_err(UndoActionError::permanent_failure)?;
+    let confirmation: CarReservation = action_context.lookup("car")?;
     // ... (make request to another service -- must not fail)
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ pub use dag::SagaDag;
 pub use dag::SagaId;
 pub use dag::SagaName;
 pub use saga_action_error::ActionError;
-pub use saga_action_error::UndoActionError;
+pub use saga_action_error::UndoActionPermanentError;
 pub use saga_action_func::new_action_noop_undo;
 pub use saga_action_func::ActionFunc;
 pub use saga_action_func::ActionFuncResult;

--- a/src/saga_action_error.rs
+++ b/src/saga_action_error.rs
@@ -4,6 +4,7 @@ use crate::saga_action_generic::ActionData;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
+use serde_json::json;
 use std::fmt::Display;
 use thiserror::Error;
 
@@ -159,4 +160,12 @@ pub enum UndoActionError {
     /// Undo action failed due to a consumer-specific error
     #[error("undo action failed permanently: {source_error:#}")]
     PermanentFailure { source_error: serde_json::Value },
+}
+
+impl UndoActionError {
+    pub fn permanent_failure(error: anyhow::Error) -> UndoActionError {
+        UndoActionError::PermanentFailure {
+            source_error: json!({ "message": format!("{:#}", error) }),
+        }
+    }
 }

--- a/src/saga_action_generic.rs
+++ b/src/saga_action_generic.rs
@@ -7,7 +7,7 @@
 use crate::saga_action_error::ActionError;
 use crate::saga_exec::ActionContext;
 use crate::ActionName;
-use crate::UndoActionError;
+use crate::UndoActionPermanentError;
 use futures::future::BoxFuture;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -63,10 +63,7 @@ impl<T: Debug + DeserializeOwned + Serialize + Send + Sync + 'static> ActionData
 pub type ActionResult = Result<Arc<serde_json::Value>, ActionError>;
 
 /// Result of a saga undo action
-// TODO-design what should the error type here be?  Maybe something that can
-// encompass "general framework error"?  This might put the saga into a "needs
-// attention" state?
-pub type UndoResult = Result<(), UndoActionError>;
+pub type UndoResult = Result<(), UndoActionPermanentError>;
 
 /// Building blocks of sagas
 ///
@@ -168,7 +165,7 @@ impl<UserType: SagaType> Action<UserType> for ActionInjectError {
     fn undo_it(&self, _: ActionContext<UserType>) -> BoxFuture<'_, UndoResult> {
         // We should never undo an action that failed.  But this same impl is
         // plugged into a saga when an "undo action" error is injected.
-        Box::pin(futures::future::err(UndoActionError::permanent_failure(
+        Box::pin(futures::future::err(UndoActionPermanentError::from(
             anyhow::anyhow!("error injected"),
         )))
     }

--- a/src/saga_action_generic.rs
+++ b/src/saga_action_generic.rs
@@ -7,6 +7,7 @@
 use crate::saga_action_error::ActionError;
 use crate::saga_exec::ActionContext;
 use crate::ActionName;
+use crate::UndoActionError;
 use futures::future::BoxFuture;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -65,7 +66,7 @@ pub type ActionResult = Result<Arc<serde_json::Value>, ActionError>;
 // TODO-design what should the error type here be?  Maybe something that can
 // encompass "general framework error"?  This might put the saga into a "needs
 // attention" state?
-pub type UndoResult = Result<(), anyhow::Error>;
+pub type UndoResult = Result<(), UndoActionError>;
 
 /// Building blocks of sagas
 ///
@@ -167,7 +168,9 @@ impl<UserType: SagaType> Action<UserType> for ActionInjectError {
     fn undo_it(&self, _: ActionContext<UserType>) -> BoxFuture<'_, UndoResult> {
         // We should never undo an action that failed.  But this same impl is
         // plugged into a saga when an "undo action" error is injected.
-        Box::pin(futures::future::err(anyhow::anyhow!("error injected")))
+        Box::pin(futures::future::err(UndoActionError::permanent_failure(
+            anyhow::anyhow!("error injected"),
+        )))
     }
 
     fn name(&self) -> ActionName {

--- a/src/saga_exec.rs
+++ b/src/saga_exec.rs
@@ -7,7 +7,6 @@ use crate::dag::InternalNode;
 use crate::dag::NodeName;
 use crate::rust_features::ExpectNone;
 use crate::saga_action_error::ActionError;
-use crate::saga_action_error::UndoActionError;
 use crate::saga_action_generic::Action;
 use crate::saga_action_generic::ActionConstant;
 use crate::saga_action_generic::ActionData;
@@ -24,6 +23,7 @@ use crate::SagaLog;
 use crate::SagaNodeEvent;
 use crate::SagaNodeId;
 use crate::SagaType;
+use crate::UndoActionPermanentError;
 use anyhow::anyhow;
 use anyhow::ensure;
 use anyhow::Context;
@@ -57,7 +57,7 @@ use tokio::task::JoinHandle;
 struct SgnsDone(Arc<serde_json::Value>);
 struct SgnsFailed(ActionError);
 struct SgnsUndone(UndoMode);
-struct SgnsUndoFailed(UndoActionError);
+struct SgnsUndoFailed(UndoActionPermanentError);
 
 struct SagaNode<S: SagaNodeStateType> {
     node_id: NodeIndex,
@@ -1505,7 +1505,7 @@ struct SagaExecLiveState {
     /// Errors produced by failed actions.
     node_errors: BTreeMap<NodeIndex, ActionError>,
     /// Errors produced by failed undo actions.
-    undo_errors: BTreeMap<NodeIndex, UndoActionError>,
+    undo_errors: BTreeMap<NodeIndex, UndoActionPermanentError>,
 
     /// Persistent state
     sglog: SagaLog,
@@ -1733,7 +1733,7 @@ pub struct SagaResultErr {
     /// details about the action failure
     pub error_source: ActionError,
     /// if an undo action also failed, details about that failure
-    pub undo_failure: Option<(NodeName, UndoActionError)>,
+    pub undo_failure: Option<(NodeName, UndoActionPermanentError)>,
 }
 
 /// Summarizes in-progress execution state of a saga

--- a/src/saga_log.rs
+++ b/src/saga_log.rs
@@ -1,7 +1,7 @@
 //! Persistent state for sagas
 
 use crate::saga_action_error::ActionError;
-use crate::saga_action_error::UndoActionError;
+use crate::saga_action_error::UndoActionPermanentError;
 use crate::SagaId;
 use anyhow::anyhow;
 use anyhow::Context;
@@ -86,7 +86,7 @@ pub enum SagaNodeEventType {
     /// The undo action has finished
     UndoFinished,
     /// The undo action has failed
-    UndoFailed(UndoActionError),
+    UndoFailed(UndoActionPermanentError),
 }
 
 impl fmt::Display for SagaNodeEventType {
@@ -133,7 +133,7 @@ pub enum SagaNodeLoadStatus {
     /// The undo action has finished successfully
     UndoFinished,
     /// The undo action has failed
-    UndoFailed(UndoActionError),
+    UndoFailed(UndoActionPermanentError),
 }
 
 impl SagaNodeLoadStatus {

--- a/src/sec.rs
+++ b/src/sec.rs
@@ -1450,7 +1450,7 @@ mod test {
     use super::*;
     use crate::{
         ActionContext, ActionError, ActionFunc, DagBuilder, Node, SagaId,
-        SagaName,
+        SagaName, UndoActionError,
     };
     use serde::{Deserialize, Serialize};
     use slog::Drain;
@@ -1526,7 +1526,7 @@ mod test {
         }
         async fn undo_n1(
             ctx: ActionContext<TestSaga>,
-        ) -> Result<(), anyhow::Error> {
+        ) -> Result<(), UndoActionError> {
             ctx.user_data().call("undo_n1");
             Ok(())
         }
@@ -1539,7 +1539,7 @@ mod test {
         }
         async fn undo_n2(
             ctx: ActionContext<TestSaga>,
-        ) -> Result<(), anyhow::Error> {
+        ) -> Result<(), UndoActionError> {
             ctx.user_data().call("undo_n2");
             Ok(())
         }

--- a/src/sec.rs
+++ b/src/sec.rs
@@ -1450,7 +1450,7 @@ mod test {
     use super::*;
     use crate::{
         ActionContext, ActionError, ActionFunc, DagBuilder, Node, SagaId,
-        SagaName, UndoActionError,
+        SagaName, UndoActionPermanentError,
     };
     use serde::{Deserialize, Serialize};
     use slog::Drain;
@@ -1526,7 +1526,7 @@ mod test {
         }
         async fn undo_n1(
             ctx: ActionContext<TestSaga>,
-        ) -> Result<(), UndoActionError> {
+        ) -> Result<(), UndoActionPermanentError> {
             ctx.user_data().call("undo_n1");
             Ok(())
         }
@@ -1539,7 +1539,7 @@ mod test {
         }
         async fn undo_n2(
             ctx: ActionContext<TestSaga>,
-        ) -> Result<(), UndoActionError> {
+        ) -> Result<(), UndoActionPermanentError> {
             ctx.user_data().call("undo_n2");
             Ok(())
         }

--- a/tests/test_smoke_run_recover_stuck_done.out
+++ b/tests/test_smoke_run_recover_stuck_done.out
@@ -44,6 +44,4 @@ failed at node:    "instance_boot"
 failed with error: error injected
 FOLLOWED BY UNDO ACTION FAILURE
 failed at node:    "instance_id"
-failed with error: undo action failed permanently: {
-  "message": "error injected"
-}
+failed with error: undo action failed permanently: error injected

--- a/tests/test_smoke_run_recover_stuck_done.out
+++ b/tests/test_smoke_run_recover_stuck_done.out
@@ -45,5 +45,5 @@ failed with error: error injected
 FOLLOWED BY UNDO ACTION FAILURE
 failed at node:    "instance_id"
 failed with error: undo action failed permanently: {
-  "message": "undo action attempt 1: error injected"
+  "message": "error injected"
 }

--- a/tests/test_smoke_run_stuck.out
+++ b/tests/test_smoke_run_stuck.out
@@ -26,6 +26,4 @@ failed at node:    "instance_boot"
 failed with error: error injected
 FOLLOWED BY UNDO ACTION FAILURE
 failed at node:    "instance_id"
-failed with error: undo action failed permanently: {
-  "message": "error injected"
-}
+failed with error: undo action failed permanently: error injected

--- a/tests/test_smoke_run_stuck.out
+++ b/tests/test_smoke_run_stuck.out
@@ -27,5 +27,5 @@ failed with error: error injected
 FOLLOWED BY UNDO ACTION FAILURE
 failed at node:    "instance_id"
 failed with error: undo action failed permanently: {
-  "message": "undo action attempt 1: error injected"
+  "message": "error injected"
 }


### PR DESCRIPTION
Following up on #138: this PR makes a few changes:

- Changed `UndoActionError` (which was an enum with one variant) to a simpler struct representing only that case.  I decided while working on this that the generality of an enum didn't seem worth it.
- Changed the type signature for undo actions to return `UndoActionPermanentError`

The goal here is to make it more obvious to authors of undo action functions that it's rather a big deal to return an error from an undo action and they should only do that for permanent errors.  This isn't a change in behavior.

This is the sort of change where we'll definitely want to convert important consumers before committing to this (i.e., landing this PR).  I've started converting Omicron, and I'm honestly not sure if this is worthwhile.  There are over 50 undo actions, and each may have a few code paths that need adjustments, and I'm not sure enough about this change to go do that.

Some design notes about this:

- I think what's most important is that when you write the type signature, the type _says_ that this is a permanent failure.
- At one point I also thought it would be nice if consumers explicitly had to wrap any error they produced with UndoActionPermanentError, but as I started making such a change mechanically, it seemed like a waste of time to convert existing stuff.
- As a result, I chose to `impl From<anyhow::Error> for UndoActionPermanentError`, figuring that any existing consumers are already producing `anyhow::Error`.  This helps, but in practice, most of the undo actions in Omicron are not directly producing `anyhow::Error`, but rather producing `omicron_common::api::external::Error`, which impl's `std::error::Error`, for which `anyhow::Error` impls `From`.  So in practice, quite a lot of call sites need to be updated anyway.
- I considered impl'ing `From<StdError> for UndoActionPermanentError`, but this would preclude it from impl'ing `StdError` directly, which means we can't use `thiserror` and can't use it like many other kinds of errors.  (This isn't a non-starter, though.)
- Anything that directly produces an `ActionError` and then uses `?` doesn't need to do anything because that can be converted to `UndoActionPermanentError`.  This is convenient for the various helper functions that Steno provides that produce `ActionError` (like `lookup()`).

We'd want to check that this change doesn't break compatibility with previously-serialized saga logs (or else that we don't care about that).

---

There are plenty of bigger questions here, too, like: should Steno first-class the idea of retryable failures?  I want to defer this discussion from this PR, unless we feel it invalidates this step.  There are a lot of tricky questions around doing this.  (What policy do we use?  How does Steno tell whether an error is retryable or not?  How does it report on transient failures?)  I think we can best approach this by prototyping with a helper function (i.e., in Omicron) that we use to wrap undo actions.  If we get to the point where we've got a stable abstraction that's a clear win and it makes sense to put it into Steno, then we can do it.