### PR TITLE
better log saga start and completion

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,6 +15,8 @@
 
 https://github.com/oxidecomputer/steno/compare/v0.4.0\...HEAD[Full list of commits]
 
+* https://github.com/oxidecomputer/steno/pull/286[#286] Steno now more consistently logs events in a saga lifetime: create/restore, start running, finish running.
+
 == 0.4.0 (released 2023-05-25)
 
 https://github.com/oxidecomputer/steno/compare/v0.3.1\...v0.4.0[Full list of commits]

--- a/src/sec.rs
+++ b/src/sec.rs
@@ -1035,10 +1035,10 @@ impl Sec {
                         format!("{:?}", error_node_name),
                     "action_error_source" => format!("{:?}", error_source),
                 ));
-                if let Some(undo) = undo_failure {
+                if let Some((node_name, error)) = undo_failure {
                     error!(&log, "saga finished";
-                        "undo_error_node_name" => ?undo.0,
-                        "undo_error" => ?undo.1,
+                        "undo_error_node_name" => ?node_name,
+                        "undo_error" => ?error,
                     );
                 } else {
                     warn!(&log, "saga finished"; "undo_result" => "success");

--- a/src/sec.rs
+++ b/src/sec.rs
@@ -1143,7 +1143,7 @@ impl Sec {
             .map_err(ActionError::new_serialize)
             .context("serializing new saga dag")
             .unwrap();
-        debug!(&log, "saga create";
+        info!(&log, "saga create";
              "dag" => serde_json::to_string(&serialized_dag).unwrap()
         );
 


### PR DESCRIPTION
It would be helpful for consumers if Steno always clearly logged when any saga is started and finished.  Then consumers don't have to have a task waiting for saga completions just to log the result.  Steno already has the saga name and saga_id, so these log messages can be pretty complete.