### PR TITLE
update GitHub Actions runners

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-20.04, windows-2022, macos-12 ]
+        os: [ ubuntu-24.04, windows-2022, macos-14 ]
     steps:
     # actions/checkout@v2
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
Recent CI jobs (even on "main") have been failing:

![Screenshot 2024-12-09 at 2 42 53 PM](https://github.com/user-attachments/assets/abacefe0-fb4c-413e-9496-df0e799067cf)

![Screenshot 2024-12-09 at 2 43 18 PM](https://github.com/user-attachments/assets/0dce66d9-46bb-4ff8-89b6-ba35d9d6e6fd)

That says:

> The macOS-12 environment is deprecated, consider switching to macOS-13, macOS-14 (macos-latest) or macOS-15. For more details, see https://github.com/actions/runner-images/issues/10721

I would expect that being "deprecated", the macos-12 image would still work.  It is still listed [on the official list of supported runners](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories).  However, it always seems to produce internal errors, and the linked issue (https://github.com/actions/runner-images/issues/10721) synopsis implies that it stopped being supported almost a week ago.

This PR updates it to macos-14.  It also updates an old Ubuntu image for good measure.